### PR TITLE
Fix: carkeys não entrega chaves

### DIFF
--- a/bridge/framework/qb.lua
+++ b/bridge/framework/qb.lua
@@ -33,7 +33,7 @@ if Shared.Framework == 'qb' then
         end
     end)
 
-    RegisterNetEvent('vehiclekeys:client:SetOwner', function(plate)
+    RegisterNetEvent('vehiclekeys:client:SetOwner', function(plate, isBuying)
         if not plate then
             return lib.notify({
                 title = 'Falhou',
@@ -41,7 +41,11 @@ if Shared.Framework == 'qb' then
                 type = 'error'
             })
         end
-        TriggerServerEvent('mm_carkeys:server:acquiretempvehiclekeys', plate)
+        if isBuying then
+            TriggerServerEvent('mm_carkeys:server:acquirevehiclekeys', plate)
+        else
+            TriggerServerEvent('mm_carkeys:server:acquiretempvehiclekeys', plate)
+        end
     end)
 
     if Shared.Inventory == 'qb' then


### PR DESCRIPTION
@mur4i gostaria de saber o que você acha dessa alteração. Dessa forma, conseguiremos usar o mesmo evento que já é disparado pelo vehicleshop e outros, apenas adicionando um parâmetro booleano quando quisermos uma chave permanente, diminuindo um pouco as alterações necessárias a cada atualização.